### PR TITLE
Upgrading IntelliJ from 2023.2.1 to 2023.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.2.1 to 2023.2.2
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Automatic GitHub Issue Navigation Configuration'
 # SemVer format -> https://semver.org
-pluginVersion = 1.1.1
+pluginVersion = 1.1.2
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 1.1.1
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.2.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.2.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 
@@ -24,7 +24,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.2.1
+platformVersion = 2023.2.2
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.2.1 to 2023.2.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661673/IntelliJ-IDEA-2023.2.2-232.9921.47-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.2.2 is out with the following improvements: 
<ul> 
 <li>In the <em>Branches</em> popup, it's now possible to disable the <em>Recent</em> section via the <em>Show Recent Branches</em> setting. [<a href="https://youtrack.jetbrains.com/issue/IDEA-326901/Allow-disabling-Recent-branches-view">IDEA-326901</a>]</li> 
 <li>The <em>Shift+Enter</em> shortcut works as expected, opening files from the <em>Search Everywhere </em>tabs in the right-hand side of the split screen. [<a href="https://youtrack.jetbrains.com/issue/IDEA-326670/">IDEA-326670</a>]</li> 
 <li>The <em>Project</em> tool window once again displays the list of directories. [<a href="https://youtrack.jetbrains.com/issue/IDEA-326394">IDEA-326394</a>]</li> 
 <li>The IDE properly recognizes Spring configuration files when importing projects from Bazel. [<a href="https://youtrack.jetbrains.com/issue/IDEA-324807/">IDEA-324807</a>]</li> 
 <li>The issue causing performance degradation when working with Markdown files featuring tables has been resolved. [<a href="https://youtrack.jetbrains.com/issue/IDEA-326905/">IDEA-326905</a>]</li> 
</ul> For more details, please refer to this 
<a href="https://blog.jetbrains.com/idea/2023/09/intellij-idea-2023-2-2/">blog post</a>.
    