### PR TITLE
Upgrading IntelliJ from 2023.3.5 to 2023.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.3.5 to 2023.3.6
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Automatic GitHub Issue Navigation Configuration'
 # SemVer format -> https://semver.org
-pluginVersion = 1.2.6
+pluginVersion = 1.2.7
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -13,7 +13,7 @@ pluginUntilBuild = 233.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.3.5,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.3.6,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 
@@ -23,7 +23,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.3.5
+platformVersion = 2023.3.6
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.3.5 to 2023.3.6

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661893/IntelliJ-IDEA-2023.3.6-233.15026.9-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.3.6 is out. This latest version brings an important fix for macOS users: 
<ul> 
 <li>We've introduced a workaround to reduce the probability of IDE crashes after updating to macOS Sonoma 14.4. [<a href="https://youtrack.jetbrains.com/issue/JBR-6802">JBR-6802</a>]</li> 
</ul> For more details, refer to our 
<a href="https://blog.jetbrains.com/idea/2024/03/intellij-idea-2023-3-6/">blog post</a>.
    