### PR TITLE
Upgrading IntelliJ from 2025.2 to 2025.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.2 to 2025.2.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/automatic-github-issue-navi
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 3.1.0
+pluginVersion = 3.1.1
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 252.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.2.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -34,7 +34,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.2
+platformVersion = 2025.2.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.2 to 2025.2.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662491/IntelliJ-IDEA-2025.2.1-252.25557.131-build-Release-Notes

# What's New?
IntelliJ IDEA 2025.2.1 is out! This release includes the following improvements: 
<ul>
 <li>The IDE correctly interprets and manages EAR artifact configurations as expected. [<a href="https://youtrack.jetbrains.com/issue/IDEA-373295">IDEA-373295</a>]</li>
 <li>The <i>Create Branch</i> action is now accessible from all parts of the UI again. [<a href="https://youtrack.jetbrains.com/issue/IJPL-199191">IJPL-199191</a>]</li>
 <li>Exporting diagrams as SVG now works as intended. [<a href="https://youtrack.jetbrains.com/issue/IJPL-174653">IJPL-174653</a>]</li>
</ul> Get more details from our <a href="https://blog.jetbrains.com/idea/2025/08/intellij-idea-2025-2-1/">blog post</a>.
    