### PR TITLE
Upgrading IntelliJ from 2026.1.4 to 2026.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [4.0.2] - 2026-05-16
 
 ### Changed
+- Upgrading IntelliJ from 2026.1.4 to 2026.2
 - Upgrading IntelliJ from 2026.1.3 to 2026.1.4
 - Upgrading IntelliJ from 2026.1.2 to 2026.1.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,12 +39,12 @@ platformVersion = 2026.2
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins = Git4Idea
-# - `intellij.platform.vcs.dvcs` is needed for importing...  in `GitHubIssueNavigationVcsRepositoryMappingListener`
+# - `intellij.platform.vcs.dvcs` is needed for importing... X ...in `GitHubIssueNavigationVcsRepositoryMappingListener`
 #       - `com.intellij.dvcs.repo.Repository`
-# - `intellij.platform.vcs.dvcs.impl` is needed for importing...
+# - `intellij.platform.vcs.dvcs.impl` is needed for importing... X ...in `GitHubIssueNavigationVcsRepositoryMappingListener`
 #       - `com.intellij.dvcs.repo.VcsRepositoryManager`
 #       - `com.intellij.dvcs.repo.VcsRepositoryMappingListener`
-# - `intellij.platform.vcs.impl.shared` is needed for importing...
+# - `intellij.platform.vcs.impl.shared` is needed for importing... X ...in `GitHubIssueNavigationVcsRepositoryMappingListener`
 #       - `com.intellij.openapi.vcs.IssueNavigationConfiguration`
 #       - `com.intellij.openapi.vcs.IssueNavigationLink`
 platformBundledModules = intellij.platform.vcs.dvcs, intellij.platform.vcs.dvcs.impl, intellij.platform.vcs.impl.shared

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ platformVersion = 2026.2
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins = Git4Idea
+platformBundledPlugins = Git4Idea, intellij.vcs.plugin
 
 # Java language level used to compile sources and to generate the files for
 # - Java 11 is required since 2020.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,16 @@ platformVersion = 2026.2
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins = Git4Idea, intellij.vcs.plugin
+platformBundledPlugins = Git4Idea
+# - `intellij.platform.vcs.dvcs` is needed for importing...  in `GitHubIssueNavigationVcsRepositoryMappingListener`
+#       - `com.intellij.dvcs.repo.Repository`
+# - `intellij.platform.vcs.dvcs.impl` is needed for importing...
+#       - `com.intellij.dvcs.repo.VcsRepositoryManager`
+#       - `com.intellij.dvcs.repo.VcsRepositoryMappingListener`
+# - `intellij.platform.vcs.impl.shared` is needed for importing...
+#       - `com.intellij.openapi.vcs.IssueNavigationConfiguration`
+#       - `com.intellij.openapi.vcs.IssueNavigationLink`
+platformBundledModules = intellij.platform.vcs.dvcs, intellij.platform.vcs.dvcs.impl, intellij.platform.vcs.impl.shared
 
 # Java language level used to compile sources and to generate the files for
 # - Java 11 is required since 2020.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,16 +8,16 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/automatic-github-issue-navi
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 4.0.4
+pluginVersion = 4.1.0
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 261
-pluginUntilBuild = 261.*
+pluginSinceBuild = 262
+pluginUntilBuild = 262.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2026.1.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2026.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -32,7 +32,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2026.1.4
+platformVersion = 2026.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,7 @@
          on how to target different products -->
     <depends>com.intellij.modules.platform</depends>
     <depends>Git4Idea</depends>
+    <depends>intellij.vcs.plugin</depends>
 
     <projectListeners>
         <listener

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,7 +11,9 @@
          on how to target different products -->
     <depends>com.intellij.modules.platform</depends>
     <depends>Git4Idea</depends>
-    <depends>intellij.vcs.plugin</depends>
+    <depends>intellij.platform.vcs.dvcs</depends>
+    <depends>intellij.platform.vcs.dvcs.impl</depends>
+    <depends>intellij.platform.vcs.impl.shared</depends>
 
     <projectListeners>
         <listener


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.1.4 to 2026.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662707

# What's New?
<p>IntelliJ IDEA 2026.2 is now out! The highlights of this release include:</p>
<p>AI upgrades:</p>
<ul>
 <li>Native GitHub Copilot integration</li>
 <li>Agent skills</li>
 <li>AI completion support for third-party providers</li>
</ul>
<p>Productivity-enhancing features:</p>
<ul>
 <li>Logpoints</li>
 <li>Dependency completion</li>
 <li>Early Gradle 10 support and migration assistance</li>
 <li>Streamlined Git conflict resolution flow</li>
 <li>Docker Compose improvements</li>
</ul>
<p>Support for new technologies:</p>
<ul>
 <li>Java 27</li>
 <li>Kotlin 2.4 Stable features</li>
 <li>Spring support improvements</li>
 <li>Terraform testing framework</li>
 <li>TypeScript 7.0</li>
</ul>
<p>Visit our <a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> to learn about these and other improvements.</p>
    