### PR TITLE
Declare VCS dependencies as IntelliJ modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- [#750](https://github.com/ChrisCarini/automatic-github-issue-navigation-configuration-jetbrains-plugin/issues/750) - Fixes issue where IDE shows error about this plugin `Requires plugin 'intellij.platform.vcs.dvcs' to be installed`.
+
 ## [4.0.2] - 2026-05-16
 
 ### Changed
@@ -12,7 +16,6 @@
 - Upgrading IntelliJ from 2026.1.4 to 2026.2
 - Upgrading IntelliJ from 2026.1.3 to 2026.1.4
 - Upgrading IntelliJ from 2026.1.2 to 2026.1.3
-
 - Upgrading IntelliJ from 2026.1.1 to 2026.1.2
 
 ## [4.0.1] - 2026-04-24

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/automatic-github-issue-navi
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 4.1.2
+pluginVersion = 4.1.3
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,9 +11,11 @@
          on how to target different products -->
     <depends>com.intellij.modules.platform</depends>
     <depends>Git4Idea</depends>
-    <depends>intellij.platform.vcs.dvcs</depends>
-    <depends>intellij.platform.vcs.dvcs.impl</depends>
-    <depends>intellij.platform.vcs.impl.shared</depends>
+    <dependencies>
+        <module name="intellij.platform.vcs.dvcs"/>
+        <module name="intellij.platform.vcs.dvcs.impl"/>
+        <module name="intellij.platform.vcs.impl.shared"/>
+    </dependencies>
 
     <projectListeners>
         <listener


### PR DESCRIPTION
Details here: https://platform.jetbrains.com/t/requires-plugin-intellij-platform-vcs-dvcs-to-be-installed/4841/3

Fixes #750