### PR TITLE
Upgrading IntelliJ from 2026.2.1 to 2026.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2026.2.1 to 2026.2.2
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,6 +59,12 @@ javaVersion = 21
 # Publish the plugin to the JetBrains Plugin Repository
 publishPlugin = true
 
+# Work around a bug in the bundled Vue.js plugin (JetBrains/intellij-platform-gradle-plugin#2183,
+# https://youtrack.jetbrains.com/issue/WEB-78747) where its classes throw an ExceptionInInitializerError
+# when loaded on the test classpath, which fails unrelated `BasePlatformTestCase`-based tests. Exclude it
+# (alongside the plugin's own default exclusions) from the `testIde` classpath until it is fixed upstream.
+org.jetbrains.intellij.platform.testIdeBundledPluginsClasspathExcludes = com.intellij.openRewrite,com.intellij.ja,com.intellij.ko,com.intellij.zh,org.jetbrains.plugins.vue
+
 ##
 # ----- NON JETBRAINS PLUGIN SETTINGS -----
 ##

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/automatic-github-issue-navi
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 4.1.3
+pluginVersion = 4.1.4
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 262.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2026.2.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2026.2.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -32,7 +32,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2026.2.1
+platformVersion = 2026.2.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.2.1 to 2026.2.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662739

# What's New?
<p>IntelliJ IDEA 2026.2.2 is out with the following improvements:</p>
<ul>
 <li>Loading a remote OpenAPI specification no longer fails. [<a href="https://youtrack.jetbrains.com/issue/IJPL-63202/">IJPL-63202</a>]</li>
 <li>The order of terminal tabs is now preserved after reopening a project. <a href="https://youtrack.jetbrains.com/issue/IJPL-212254/Terminal-tabs-order-is-not-saved-in-IntelliJ">[IJPL-212254</a>]</li>
 <li>Checkboxes in Markdown now have improved contrast for better visibility. [<a href="https://youtrack.jetbrains.com/issue/IJPL-93391/Low-contrast-of-checkboxes-in-markdown">IJPL-93391</a>]</li>
 <li>The vertical scrollbar is once again displayed correctly in the Markdown preview pane. [<a href="https://youtrack.jetbrains.com/issue/IJPL-251259/2026.2-Markdown-Preview-Missing-vertical-scrollbar-JCEF-rendering-failure">IJPL-251259</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2026/09/intellij-idea-2026-2-2/">blog post</a>.</p>
    